### PR TITLE
Fix outbox messages rendering

### DIFF
--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -10,7 +10,15 @@ const OutboxList = () => {
     const fetchOutbox = async () => {
       try {
         const { data } = await axiosReq.get("/outbox/");
-        setMessages(data);
+        // Some endpoints return an object with a `results` array while others
+        // return the array directly. Normalize the value so `messages` is
+        // always an array.
+        const outboxMessages = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.results)
+          ? data.results
+          : [];
+        setMessages(outboxMessages);
       } catch (err) {
         console.error(err);
       }
@@ -21,12 +29,19 @@ const OutboxList = () => {
 
   if (loading) return <div>Loading...</div>;
 
+  // Guard against unexpected data shapes to prevent runtime errors
+  const messageList = Array.isArray(messages)
+    ? messages
+    : Array.isArray(messages?.results)
+    ? messages.results
+    : [];
+
   return (
     <div>
       <h2>Outbox</h2>
-      {messages.length === 0 && <div>No sent messages.</div>}
+      {messageList.length === 0 && <div>No sent messages.</div>}
       <ul>
-        {messages.map((msg) => (
+        {messageList.map((msg) => (
           <li key={msg.id}>
             <b>To:</b> {msg.recipient_username} <b>Subject:</b> {msg.subject}{" "}
             <Link to={`/messages/${msg.id}`}>View</Link>


### PR DESCRIPTION
## Summary
- normalize messages returned from `/outbox/` endpoint
- guard against non-array responses when rendering the outbox list

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc6c410c8330a7e79593e374e8c7