### PR TITLE
Fix route for new messages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -194,7 +194,7 @@ function App() {
           />
           <Route
             exact
-            path="/messages/send"
+            path="/messages/new"
             render={() =>
               currentUser ? <DirectMessageForm /> : <Redirect to="/signin" />
             }


### PR DESCRIPTION
## Summary
- correct the message creation route to `/messages/new`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684009890c248330ad72cfbaf4fca2b0