### PR TITLE
Fix message details display

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
 import { useParams } from "react-router-dom";
+import { useCurrentUser } from "../../contexts/CurrentUserContext";
+import styles from "../../styles/DirectMessageDetail.module.css";
 
 const DirectMessageDetail = () => {
   const { id } = useParams();
   const [msg, setMsg] = useState(null);
+  const currentUser = useCurrentUser();
 
   useEffect(() => {
     const fetchMsg = async () => {
@@ -24,16 +27,27 @@ const DirectMessageDetail = () => {
 
   if (!msg) return <div>Loading...</div>;
 
+  const toLabel =
+    msg.recipient_username === currentUser?.username
+      ? "You"
+      : msg.recipient_username;
+
   return (
-    <div>
-      <h3>Subject: {msg.subject}</h3>
-      <p>
-        <b>From:</b> {msg.sender_username} <b>To:</b> {msg.recipient_username}
-      </p>
-      <p>{msg.body}</p>
-      <p>
-        <b>Date:</b> {msg.created_at} | <b>Status:</b> {msg.read ? "Read" : "Unread"}
-      </p>
+    <div className={styles.Container}>
+      <h3 className={styles.Subject}>Subject: {msg.subject}</h3>
+      <div className={styles.Meta}>
+        <b>From:</b> {msg.sender_username}
+      </div>
+      <div className={styles.Meta}>
+        <b>To:</b> {toLabel}
+      </div>
+      <div className={styles.Content}>{msg.content}</div>
+      <div className={styles.Meta}>
+        <b>Date:</b> {msg.created_at}
+      </div>
+      <div className={styles.Meta}>
+        <b>Status:</b> {msg.read ? "Read" : "Unread"}
+      </div>
     </div>
   );
 };

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -1,0 +1,24 @@
+.Container {
+  max-width: 600px;
+  margin: 40px auto;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  font-size: 1rem;
+}
+
+.Subject {
+  text-align: center;
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
+.Meta {
+  margin-bottom: 10px;
+}
+
+.Content {
+  margin: 20px 0;
+  white-space: pre-line;
+}


### PR DESCRIPTION
## Summary
- show full message details for inbox and outbox
- add styling for the message detail view

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494d5815e483308014ae730664630e