### PR TITLE
Fix message detail display and read state

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -14,8 +14,11 @@ const DirectMessageDetail = () => {
       try {
         const { data } = await axiosReq.get(`/messages/${id}/`);
         setMsg(data);
-        // Opcjonalnie PATCH oznaczenie przeczytanej
-        if (!data.read) {
+        // Mark as read only if the current user is the recipient
+        if (
+          data.recipient_username === currentUser?.username &&
+          !data.read
+        ) {
           await axiosReq.patch(`/messages/${id}/`, { read: true });
         }
       } catch (err) {
@@ -23,14 +26,12 @@ const DirectMessageDetail = () => {
       }
     };
     fetchMsg();
-  }, [id]);
+  }, [id, currentUser]);
 
   if (!msg) return <div>Loading...</div>;
 
-  const toLabel =
-    msg.recipient_username === currentUser?.username
-      ? "You"
-      : msg.recipient_username;
+  const isRecipient = msg.recipient_username === currentUser?.username;
+  const receiverLabel = msg.receiver_username || msg.recipient_username;
 
   return (
     <div className={styles.Container}>
@@ -38,9 +39,11 @@ const DirectMessageDetail = () => {
       <div className={styles.Meta}>
         <b>From:</b> {msg.sender_username}
       </div>
-      <div className={styles.Meta}>
-        <b>To:</b> {toLabel}
-      </div>
+      {!isRecipient && (
+        <div className={styles.Meta}>
+          <b>To:</b> {receiverLabel}
+        </div>
+      )}
       <div className={styles.Content}>{msg.content}</div>
       <div className={styles.Meta}>
         <b>Date:</b> {msg.created_at}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -19,7 +19,9 @@ const OutboxList = () => {
           : Array.isArray(data?.results)
           ? data.results
           : [];
-        setMessages(outboxMessages);
+        // Mark outbox messages as read by default so they aren't shown as unread
+        const markedRead = outboxMessages.map((msg) => ({ ...msg, read: true }));
+        setMessages(markedRead);
       } catch (err) {
         console.error(err);
       }
@@ -45,7 +47,7 @@ const OutboxList = () => {
         {messageList.map((msg) => (
           <li key={msg.id} className={styles.Message}>
             <div>
-              <b>To:</b> {msg.recipient_username}
+              <b>To:</b> {msg.receiver_username || msg.recipient_username}
             </div>
             <div>
               <b>Subject:</b> {msg.subject}


### PR DESCRIPTION
## Summary
- mark outbox messages as read after fetch
- show receiver username in Outbox list
- only patch messages as read if viewing as recipient
- hide "To" line when viewing as message recipient

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849597b12b88330bc4c09a9852ead23