### PR TITLE
Add SweetAlert2 alerts for direct messaging

### DIFF
--- a/src/pages/inbox/DirectMessageForm.js
+++ b/src/pages/inbox/DirectMessageForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
 import styles from "../../styles/DirectMessageForm.module.css";
+import Swal from "sweetalert2";
 
 const DirectMessageForm = () => {
   const [receiver, setReceiver] = useState("");
@@ -14,8 +15,32 @@ const DirectMessageForm = () => {
       setReceiver("");
       setSubject("");
       setContent("");
+
+      Swal.fire({
+        icon: "success",
+        title: "Message Sent",
+        text: "Your message was successfully delivered.",
+        confirmButtonColor: "#3085d6",
+      });
     } catch (err) {
-      console.error(err);
+      if (
+        err.response?.status === 400 &&
+        err.response.data?.receiver?.[0] === "User does not exist."
+      ) {
+        Swal.fire({
+          icon: "error",
+          title: "User Not Found",
+          text: "The recipient username does not exist. Please check and try again.",
+          confirmButtonColor: "#d33",
+        });
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "Error",
+          text: "Something went wrong while sending the message.",
+          confirmButtonColor: "#d33",
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- notify users with SweetAlert2 when sending direct messages

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849803574508330a1f6dfa6318c1a07