### PR TITLE
Revamp messaging pages with card layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "^5.0.1",
+    "lucide-react": "^0.292.0",
     "sweetalert2": "^11.14.5",
     "typescript": "^4.4.0",
     "web-vitals": "^1.1.2"

--- a/src/components/ui/badge.js
+++ b/src/components/ui/badge.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+const variantClasses = {
+  secondary: "bg-gray-200 text-gray-800",
+  outline: "border border-gray-400 text-gray-800",
+  default: "bg-blue-500 text-white",
+};
+
+export const Badge = ({ variant = "default", children, className = "" }) => (
+  <span className={`px-2 py-1 rounded text-sm ${variantClasses[variant]} ${className}`}>
+    {children}
+  </span>
+);
+
+export default Badge;

--- a/src/components/ui/button.js
+++ b/src/components/ui/button.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const Button = ({ to, children, className = "" }) => {
+  const base = "bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d]";
+  if (to) {
+    return (
+      <Link to={to} className={`${base} ${className}`}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <button type="button" className={`${base} ${className}`}> 
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/ui/card.js
+++ b/src/components/ui/card.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+export const Card = ({ children, className = "" }) => (
+  <div className={`bg-white rounded-2xl shadow p-4 ${className}`}>{children}</div>
+);
+
+export const CardHeader = ({ children, className = "" }) => (
+  <div className={`mb-2 font-semibold flex items-center gap-2 ${className}`}>{children}</div>
+);
+
+export const CardContent = ({ children, className = "" }) => (
+  <div className={`mb-2 ${className}`}>{children}</div>
+);
+
+export const CardFooter = ({ children, className = "" }) => (
+  <div className={`mt-4 flex justify-between items-center ${className}`}>{children}</div>
+);
+
+export default Card;

--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -3,6 +3,9 @@ import { axiosReq } from "../../api/axiosDefaults";
 import { useParams } from "react-router-dom";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
 import styles from "../../styles/DirectMessageDetail.module.css";
+import { Mail, User, Calendar } from "lucide-react";
+import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
+import Badge from "../../components/ui/badge";
 
 const DirectMessageDetail = () => {
   const { id } = useParams();
@@ -35,22 +38,34 @@ const DirectMessageDetail = () => {
 
   return (
     <div className={styles.Container}>
-      <h3 className={styles.Subject}>Subject: {msg.subject}</h3>
-      <div className={styles.Meta}>
-        <b>From:</b> {msg.sender_username}
-      </div>
-      {!isRecipient && (
-        <div className={styles.Meta}>
-          <b>To:</b> {receiverLabel}
-        </div>
-      )}
-      <div className={styles.Content}>{msg.content}</div>
-      <div className={styles.Meta}>
-        <b>Date:</b> {msg.created_at}
-      </div>
-      <div className={styles.Meta}>
-        <b>Status:</b> {msg.read ? "Read" : "Unread"}
-      </div>
+      <Card className="space-y-2">
+        <CardHeader className="text-lg">
+          <Mail className="w-4 h-4" />
+          <span>{msg.subject}</span>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2">
+          <User className="w-4 h-4" />
+          <span>From: {msg.sender_username}</span>
+        </CardContent>
+        {!isRecipient && (
+          <CardContent className="flex items-center gap-2">
+            <User className="w-4 h-4" />
+            <span>To: {receiverLabel}</span>
+          </CardContent>
+        )}
+        <CardContent className="whitespace-pre-line">
+          {msg.content}
+        </CardContent>
+        <CardContent className="flex items-center gap-2 text-sm text-gray-500">
+          <Calendar className="w-4 h-4" />
+          <span>{msg.created_at}</span>
+        </CardContent>
+        <CardFooter className="justify-end">
+          <Badge variant={msg.read ? "outline" : "secondary"}>
+            {msg.read ? "Read" : "Unread"}
+          </Badge>
+        </CardFooter>
+      </Card>
     </div>
   );
 };

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Link } from "react-router-dom";
+import { Mail, User } from "lucide-react";
 import styles from "../../styles/InboxList.module.css";
+import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
+import Badge from "../../components/ui/badge";
+import Button from "../../components/ui/button";
 
 const InboxList = () => {
   const [messages, setMessages] = useState([]);
@@ -41,25 +44,29 @@ const InboxList = () => {
     <div className={styles.Container}>
       <h2 className={styles.Title}>Inbox</h2>
       {messageList.length === 0 && <div>No messages.</div>}
-      <ul className={styles.List}>
+      <div className="flex flex-col gap-4">
         {messageList.map((msg) => (
-          <li
+          <Card
             key={msg.id}
-            className={`${styles.Message} ${!msg.read ? styles.Unread : ""}`}
+            className={`${!msg.read ? "bg-gray-100" : ""}`}
           >
-            <div>
-              <b>From:</b> {msg.sender_username}
-              {!msg.read && <span className={styles.UnreadTag}>Unread</span>}
-            </div>
-            <div>
-              <b>Subject:</b> {msg.subject}
-            </div>
-            <Link to={`/messages/${msg.id}`} className={styles.Link}>
-              View
-            </Link>
-          </li>
+            <CardHeader>
+              <User className="w-4 h-4" />
+              <span>From: {msg.sender_username}</span>
+            </CardHeader>
+            <CardContent className="flex items-center gap-2">
+              <Mail className="w-4 h-4" />
+              <span>Subject: {msg.subject}</span>
+            </CardContent>
+            <CardFooter>
+              <Badge variant={msg.read ? "outline" : "secondary"}>
+                {msg.read ? "Read" : "Unread"}
+              </Badge>
+              <Button to={`/messages/${msg.id}`}>View</Button>
+            </CardFooter>
+          </Card>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Link } from "react-router-dom";
+import { Mail, User } from "lucide-react";
 import styles from "../../styles/OutboxList.module.css";
+import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
+import Badge from "../../components/ui/badge";
+import Button from "../../components/ui/button";
 
 const OutboxList = () => {
   const [messages, setMessages] = useState([]);
@@ -43,21 +46,24 @@ const OutboxList = () => {
     <div className={styles.Container}>
       <h2 className={styles.Title}>Outbox</h2>
       {messageList.length === 0 && <div>No sent messages.</div>}
-      <ul className={styles.List}>
+      <div className="flex flex-col gap-4">
         {messageList.map((msg) => (
-          <li key={msg.id} className={styles.Message}>
-            <div>
-              <b>To:</b> {msg.receiver_username || msg.recipient_username}
-            </div>
-            <div>
-              <b>Subject:</b> {msg.subject}
-            </div>
-            <Link to={`/messages/${msg.id}`} className={styles.Link}>
-              View
-            </Link>
-          </li>
+          <Card key={msg.id}>
+            <CardHeader>
+              <User className="w-4 h-4" />
+              <span>To: {msg.receiver_username || msg.recipient_username}</span>
+            </CardHeader>
+            <CardContent className="flex items-center gap-2">
+              <Mail className="w-4 h-4" />
+              <span>Subject: {msg.subject}</span>
+            </CardContent>
+            <CardFooter>
+              <Badge variant="outline">Sent</Badge>
+              <Button to={`/messages/${msg.id}`}>View</Button>
+            </CardFooter>
+          </Card>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- integrate lucide-react icons
- add new UI components: Card, Badge, and Button
- redesign Inbox, Outbox and message detail views to use cards

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849851c1c8c8330ae1a4ec880a81298