### PR TITLE
Improve view button visibility in messaging lists

### DIFF
--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Mail, User, Eye } from "lucide-react";
+import { Mail, User, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import styles from "../../styles/InboxList.module.css";
 import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
 import Badge from "../../components/ui/badge";
-import Button from "../../components/ui/button";
 
 const InboxList = () => {
   const [messages, setMessages] = useState([]);
@@ -62,10 +62,13 @@ const InboxList = () => {
               <Badge variant={msg.read ? "outline" : "secondary"}>
                 {msg.read ? "Read" : "Unread"}
               </Badge>
-              <Button to={`/messages/${msg.id}`}>
-                <Eye className="w-4 h-4" />
+              <Link
+                to={`/messages/${msg.id}`}
+                className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
+              >
+                <ArrowRight className="w-4 h-4" />
                 View
-              </Button>
+              </Link>
             </CardFooter>
           </Card>
         ))}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Mail, User, Eye } from "lucide-react";
+import { Mail, User, ArrowRight } from "lucide-react";
+import { Link } from "react-router-dom";
 import styles from "../../styles/OutboxList.module.css";
 import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
 import Badge from "../../components/ui/badge";
-import Button from "../../components/ui/button";
 
 const OutboxList = () => {
   const [messages, setMessages] = useState([]);
@@ -59,10 +59,13 @@ const OutboxList = () => {
             </CardContent>
             <CardFooter>
               <Badge variant="outline">Sent</Badge>
-              <Button to={`/messages/${msg.id}`}>
-                <Eye className="w-4 h-4" />
+              <Link
+                to={`/messages/${msg.id}`}
+                className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
+              >
+                <ArrowRight className="w-4 h-4" />
                 View
-              </Button>
+              </Link>
             </CardFooter>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- adjust Inbox and Outbox message lists to show a visible **View** button
- use Tailwind styling and arrow icon

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499d7eac588330b12b2311f6946637