### PR TITLE
Enhance messaging UI

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
 import styles from "../../styles/DirectMessageDetail.module.css";
 import { Mail, User, Calendar } from "lucide-react";
@@ -11,6 +11,7 @@ const DirectMessageDetail = () => {
   const { id } = useParams();
   const [msg, setMsg] = useState(null);
   const currentUser = useCurrentUser();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchMsg = async () => {
@@ -38,6 +39,12 @@ const DirectMessageDetail = () => {
 
   return (
     <div className={styles.Container}>
+      <button
+        onClick={() => navigate(-1)}
+        className="text-sm text-blue-600 hover:underline mb-4"
+      >
+        ← Back to messages
+      </button>
       <Card className="space-y-2">
         <CardHeader className="text-lg">
           <Mail className="w-4 h-4" />

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -58,7 +58,7 @@ const InboxList = () => {
               <Mail className="w-4 h-4" />
               <span>Subject: {msg.subject}</span>
             </CardContent>
-            <CardFooter>
+            <CardFooter className="flex items-center justify-between">
               <Badge variant={msg.read ? "outline" : "secondary"}>
                 {msg.read ? "Read" : "Unread"}
               </Badge>
@@ -66,8 +66,8 @@ const InboxList = () => {
                 to={`/messages/${msg.id}`}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
-                <ArrowRight className="w-4 h-4" />
                 View
+                <ArrowRight className="w-4 h-4" />
               </Link>
             </CardFooter>
           </Card>

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -57,14 +57,16 @@ const OutboxList = () => {
               <Mail className="w-4 h-4" />
               <span>Subject: {msg.subject}</span>
             </CardContent>
-            <CardFooter>
-              <Badge variant="outline">Sent</Badge>
+            <CardFooter className="flex items-center justify-between">
+              <Badge variant={msg.read ? "outline" : "secondary"}>
+                {msg.read ? "Read" : "Unread"}
+              </Badge>
               <Link
                 to={`/messages/${msg.id}`}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
-                <ArrowRight className="w-4 h-4" />
                 View
+                <ArrowRight className="w-4 h-4" />
               </Link>
             </CardFooter>
           </Card>


### PR DESCRIPTION
## Summary
- show read status and new View button layout on Inbox and Outbox pages
- add navigation back button to direct message detail

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a03a7a4483308543ef12bfcd0089