### PR TITLE
Improve messaging UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -148,7 +148,7 @@ function App() {
             element={currentUser ? <DirectMessageForm /> : <Navigate to="/signin" />}
           />
           <Route
-            path="/messages/:id"
+            path="/messages/:id/"
             element={currentUser ? <DirectMessageDetail /> : <Navigate to="/signin" />}
           />
           {/* === KONIEC ROUTES DLA WIADOMOŚCI === */}

--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -35,15 +35,19 @@ const DirectMessageDetail = () => {
   if (!msg) return <div>Loading...</div>;
 
   const isRecipient = msg.recipient_username === currentUser?.username;
-  const receiverLabel = msg.receiver_username || msg.recipient_username;
+  const receiverLabel =
+    msg.receiver_username ||
+    msg.recipient_username ||
+    msg.receiver ||
+    msg.recipient;
 
   return (
     <div className={styles.Container}>
       <button
-        onClick={() => navigate(-1)}
+        onClick={() => navigate(isRecipient ? "/inbox" : "/outbox")}
         className="text-sm text-blue-600 hover:underline mb-4"
       >
-        ← Back to messages
+        ← Back to {isRecipient ? "Inbox" : "Outbox"}
       </button>
       <Card className="space-y-2">
         <CardHeader className="text-lg">
@@ -52,12 +56,14 @@ const DirectMessageDetail = () => {
         </CardHeader>
         <CardContent className="flex items-center gap-2">
           <User className="w-4 h-4" />
-          <span>From: {msg.sender_username}</span>
+          <span className="font-semibold">From:</span>
+          <span>{msg.sender_username}</span>
         </CardContent>
         {!isRecipient && (
           <CardContent className="flex items-center gap-2">
             <User className="w-4 h-4" />
-            <span>To: {receiverLabel}</span>
+            <span className="font-semibold">To:</span>
+            <span>{receiverLabel}</span>
           </CardContent>
         )}
         <CardContent className="whitespace-pre-line">

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -52,18 +52,20 @@ const InboxList = () => {
           >
             <CardHeader>
               <User className="w-4 h-4" />
-              <span>From: {msg.sender_username}</span>
+              <span className="font-semibold">From:</span>
+              <span>{msg.sender_username}</span>
             </CardHeader>
             <CardContent className="flex items-center gap-2">
               <Mail className="w-4 h-4" />
-              <span>Subject: {msg.subject}</span>
+              <span className="font-semibold">Subject:</span>
+              <span>{msg.subject}</span>
             </CardContent>
             <CardFooter className="flex items-center justify-between">
               <Badge variant={msg.read ? "outline" : "secondary"}>
                 {msg.read ? "Read" : "Unread"}
               </Badge>
               <Link
-                to={`/messages/${msg.id}`}
+                to={`/messages/${msg.id}/`}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
                 View

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -51,18 +51,25 @@ const OutboxList = () => {
           <Card key={msg.id}>
             <CardHeader>
               <User className="w-4 h-4" />
-              <span>To: {msg.receiver_username || msg.recipient_username}</span>
+              <span className="font-semibold">To:</span>
+              <span>
+                {msg.receiver_username ||
+                  msg.recipient_username ||
+                  msg.receiver ||
+                  msg.recipient}
+              </span>
             </CardHeader>
             <CardContent className="flex items-center gap-2">
               <Mail className="w-4 h-4" />
-              <span>Subject: {msg.subject}</span>
+              <span className="font-semibold">Subject:</span>
+              <span>{msg.subject}</span>
             </CardContent>
             <CardFooter className="flex items-center justify-between">
               <Badge variant={msg.read ? "outline" : "secondary"}>
                 {msg.read ? "Read" : "Unread"}
               </Badge>
               <Link
-                to={`/messages/${msg.id}`}
+                to={`/messages/${msg.id}/`}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
                 View


### PR DESCRIPTION
## Summary
- enhance inbox message card formatting and routing
- show full recipient in outbox messages
- update message detail page with bold labels and back navigation
- support trailing slash routes for message detail

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa5cc71c8330be546d41ffcd3f01