### PR TITLE
Fix message read status and dynamic back link

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
 import styles from "../../styles/DirectMessageDetail.module.css";
 import { Mail, User, Calendar } from "lucide-react";
@@ -12,6 +12,7 @@ const DirectMessageDetail = () => {
   const [msg, setMsg] = useState(null);
   const currentUser = useCurrentUser();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     const fetchMsg = async () => {
@@ -40,6 +41,16 @@ const DirectMessageDetail = () => {
     msg.recipient_username ||
     msg.receiver ||
     msg.recipient;
+  const cameFrom = location.state?.from;
+  const backTarget =
+    cameFrom === "inbox"
+      ? "/inbox"
+      : cameFrom === "outbox"
+      ? "/outbox"
+      : isRecipient
+      ? "/inbox"
+      : "/outbox";
+  const backLabel = backTarget === "/inbox" ? "Inbox" : "Outbox";
   const formattedDate = new Date(msg.created_at).toLocaleDateString(
     "en-GB",
     { day: "2-digit", month: "short", year: "numeric" }
@@ -48,10 +59,10 @@ const DirectMessageDetail = () => {
   return (
     <div className={styles.Container}>
       <button
-        onClick={() => navigate(isRecipient ? "/inbox" : "/outbox")}
+        onClick={() => navigate(backTarget)}
         className="text-sm text-blue-600 hover:underline mb-4"
       >
-        ← Back to {isRecipient ? "Inbox" : "Outbox"}
+        ← Back to {backLabel}
       </button>
       <Card className="space-y-2">
         <CardHeader className="text-lg">
@@ -78,9 +89,18 @@ const DirectMessageDetail = () => {
           <span>{formattedDate}</span>
         </CardContent>
         <CardFooter className="justify-end">
-          <Badge variant={msg.read ? "outline" : "secondary"}>
-            {msg.read ? "Read" : "Unread"}
-          </Badge>
+          {(() => {
+            const isRead =
+              msg.read === true ||
+              msg.read === "true" ||
+              msg.read === 1 ||
+              msg.read === "1";
+            return (
+              <Badge variant={isRead ? "outline" : "secondary"}>
+                {isRead ? "Read" : "Unread"}
+              </Badge>
+            );
+          })()}
         </CardFooter>
       </Card>
     </div>

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -61,11 +61,21 @@ const InboxList = () => {
               <span>{msg.subject}</span>
             </CardContent>
             <CardFooter className="flex items-center justify-between">
-              <Badge variant={msg.read ? "outline" : "secondary"}>
-                {msg.read ? "Read" : "Unread"}
-              </Badge>
+              {(() => {
+                const isRead =
+                  msg.read === true ||
+                  msg.read === "true" ||
+                  msg.read === 1 ||
+                  msg.read === "1";
+                return (
+                  <Badge variant={isRead ? "outline" : "secondary"}>
+                    {isRead ? "Read" : "Unread"}
+                  </Badge>
+                );
+              })()}
               <Link
                 to={`/messages/${msg.id}/`}
+                state={{ from: "inbox" }}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
                 View

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -65,11 +65,21 @@ const OutboxList = () => {
               <span>{msg.subject}</span>
             </CardContent>
             <CardFooter className="flex items-center justify-between">
-              <Badge variant={msg.read ? "outline" : "secondary"}>
-                {msg.read ? "Read" : "Unread"}
-              </Badge>
+              {(() => {
+                const isRead =
+                  msg.read === true ||
+                  msg.read === "true" ||
+                  msg.read === 1 ||
+                  msg.read === "1";
+                return (
+                  <Badge variant={isRead ? "outline" : "secondary"}>
+                    {isRead ? "Read" : "Unread"}
+                  </Badge>
+                );
+              })()}
               <Link
                 to={`/messages/${msg.id}/`}
+                state={{ from: "outbox" }}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >
                 View


### PR DESCRIPTION
## Summary
- show message read/unread badges on the inbox and outbox lists
- include page source state in message links
- display correct back link in message detail page based on where user came from
- be tolerant of string/integer `read` values when rendering badges

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4bf8c87c83309f9fe37ddd91c014