### PR TITLE
Fix outbox Read link

### DIFF
--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -74,7 +74,7 @@ const InboxList = () => {
                 );
               })()}
               <Link
-                to={`/messages/${msg.id}`}
+                to={`/messages/${msg.id}/`}
                 state={{ from: "inbox" }}
                 className={styles.readButton}
               >

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -78,7 +78,7 @@ const OutboxList = () => {
                 );
               })()}
               <Link
-                to={`/messages/${msg.id}`}
+                to={`/messages/${msg.id}/`}
                 state={{ from: "outbox" }}
                 className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
               >


### PR DESCRIPTION
## Summary
- correct the message details link in outbox and inbox pages so it includes a trailing slash

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6408c9108330ace6a682fa87a38f