### PR TITLE
Align OutboxList with Inbox styling

### DIFF
--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -48,7 +48,10 @@ const OutboxList = () => {
       {messageList.length === 0 && <div>No sent messages.</div>}
       <div className="flex flex-col gap-4">
         {messageList.map((msg) => (
-          <Card key={msg.id}>
+          <Card
+            key={msg.id}
+            className={`${!msg.read ? "bg-gray-100" : ""}`}
+          >
             <CardHeader>
               <User className="w-4 h-4" />
               <span className="font-semibold">To:</span>
@@ -80,7 +83,7 @@ const OutboxList = () => {
               <Link
                 to={`/messages/${msg.id}/`}
                 state={{ from: "outbox" }}
-                className="inline-flex items-center gap-1 bg-[#2142b2] text-white px-4 py-2 rounded hover:bg-[#242a3d] transition"
+                className={styles.readButton}
               >
                 Read
               </Link>

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -39,3 +39,21 @@
     font-size: 0.9rem;
   }
 }
+
+.readButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #2142b2;
+  color: white;
+  font-weight: 600;
+  padding: 10px 16px;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.2s ease-in-out;
+  text-decoration: none;
+}
+
+.readButton:hover {
+  background-color: #1b36a0;
+}


### PR DESCRIPTION
## Summary
- use the same card layout as InboxList
- reuse rounded blue `Read` button styling

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a6732e1bc8330957f34c83847e63d