### PR TITLE
Fix unread badge display

### DIFF
--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -67,11 +67,9 @@ const InboxList = () => {
                   msg.read === "true" ||
                   msg.read === 1 ||
                   msg.read === "1";
-                return (
-                  <Badge variant={isRead ? "outline" : "secondary"}>
-                    {isRead ? "Read" : "Unread"}
-                  </Badge>
-                );
+                return !isRead ? (
+                  <Badge variant="secondary">Unread</Badge>
+                ) : null;
               })()}
               <Link
                 to={`/messages/${msg.id}/`}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -74,11 +74,9 @@ const OutboxList = () => {
                   msg.read === "true" ||
                   msg.read === 1 ||
                   msg.read === "1";
-                return (
-                  <Badge variant={isRead ? "outline" : "secondary"}>
-                    {isRead ? "Read" : "Unread"}
-                  </Badge>
-                );
+                return !isRead ? (
+                  <Badge variant="secondary">Unread</Badge>
+                ) : null;
               })()}
               <Link
                 to={`/messages/${msg.id}/`}


### PR DESCRIPTION
## Summary
- only show badge for unread messages in inbox and outbox

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6ceec5ec8330ba14c6b714d085cd