### PR TITLE
Add read status and hide self labels on messages

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -38,6 +38,7 @@ const DirectMessageDetail = () => {
   if (!msg) return <div>Loading...</div>;
 
   const isRecipient = msg.recipient_username === currentUser?.username;
+  const isSender = msg.sender_username === currentUser?.username;
   const receiverLabel =
     msg.receiver_username ||
     msg.recipient_username ||
@@ -77,13 +78,15 @@ const DirectMessageDetail = () => {
           </span>
           <span>{msg.subject}</span>
         </div>
-        <div className={styles.Meta}>
-          <span role="img" aria-label="from">
-            👤
-          </span>
-          <span>From:</span>
-          <span>{msg.sender_username}</span>
-        </div>
+        {!isSender && (
+          <div className={styles.Meta}>
+            <span role="img" aria-label="from">
+              👤
+            </span>
+            <span>From:</span>
+            <span>{msg.sender_username}</span>
+          </div>
+        )}
         {!isRecipient && (
           <div className={styles.Meta}>
             <span role="img" aria-label="to">
@@ -105,6 +108,16 @@ const DirectMessageDetail = () => {
           </span>
           <span>{formattedDate}</span>
         </div>
+        {isSender && (
+          <div className={styles.Status}>
+            <span role="img" aria-label="status">
+              {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "✅" : "📩"}
+            </span>
+            <span>
+              {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "Read" : "Unread"}
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -50,3 +50,12 @@
   font-size: 0.875rem;
   color: #555;
 }
+
+.Status {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: #555;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- hide `From:` line when current user is the sender
- keep `To:` line hidden when viewing own inbox
- show a read/unread status indicator for sent messages

## Testing
- `npm test --silent -- -w=1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a85d9dda083308f5f83131fcdce4d