### PR TITLE
Refactor message views

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -50,12 +50,6 @@ const DirectMessageDetail = () => {
   const isSender =
     msg.sender_username === currentUser?.username ||
     msg.owner === currentUser?.username;
-  const receiverLabel =
-    msg.receiver_username ||
-    msg.recipient_username ||
-    msg.to_user?.username ||
-    msg.receiver ||
-    msg.recipient;
   const cameFrom = location.state?.from;
   const backTarget =
     cameFrom === "inbox"
@@ -84,50 +78,11 @@ const DirectMessageDetail = () => {
         ← Back to {backLabel}
       </button>
       <div className={styles.Card}>
-        <div className={styles.Subject}>
-          <span role="img" aria-label="subject">
-            📧
-          </span>
-          <span>{msg.subject}</span>
-        </div>
-        {!isSender && (
-          <div className={styles.Meta}>
-            <span role="img" aria-label="from">
-              👤
-            </span>
-            <span>From:</span>
-            <span>{msg.sender_username}</span>
-          </div>
-        )}
-        {!isRecipient && (
-          <div className={styles.Meta}>
-            <span role="img" aria-label="to">
-              👤
-            </span>
-            <span>To:</span>
-            <span>{receiverLabel}</span>
-          </div>
-        )}
-        <div className={styles.Content}>
-          <span role="img" aria-label="message">
-            💬
-          </span>
-          <span>{msg.content}</span>
-        </div>
-        <div className={styles.Date}>
-          <span role="img" aria-label="date">
-            📅
-          </span>
-          <span>{formattedDate}</span>
-        </div>
+        <div className={styles.Content}>{msg.content}</div>
+        <div className={styles.Date}>{formattedDate}</div>
         {isSender && (
           <div className={styles.Status}>
-            <span role="img" aria-label="status">
-              {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "✅" : "📩"}
-            </span>
-            <span>
-              {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "Read" : "Unread"}
-            </span>
+            {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "Read" : "Unread"}
           </div>
         )}
       </div>

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Mail, User } from "lucide-react";
+
 import { Link } from "react-router-dom";
 import styles from "./InboxList.module.css";
 
@@ -38,32 +38,32 @@ const InboxList = () => {
     ? messages.results
     : [];
 
+  const sortedMessages = [...messageList].sort(
+    (a, b) => new Date(b.created_at) - new Date(a.created_at)
+  );
+
   return (
     <div className={styles.Container}>
       <h2 className={styles.Title}>Inbox</h2>
       {messageList.length === 0 && <div>No messages.</div>}
       <ul className={styles.List}>
-        {messageList.map((msg) => {
+        {sortedMessages.map((msg) => {
           const isRead =
             msg.read === true ||
             msg.read === "true" ||
             msg.read === 1 ||
             msg.read === "1";
+          const formattedDate = new Date(msg.created_at).toLocaleDateString(
+            "en-GB",
+            { day: "2-digit", month: "short", year: "numeric" }
+          );
           return (
             <li key={msg.id} className={styles.Message}>
               <div className={styles.MessageHeader}>
-                <div className="flex items-center gap-2">
-                  <User className="w-4 h-4" />
-                  <span className="font-semibold">From:</span>
-                  <span>{msg.sender_username}</span>
-                </div>
+                <span className={styles.Date}>{formattedDate}</span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
-              <div className={styles.MessageBody}>
-                <Mail className="w-4 h-4" />
-                <span className="font-semibold">Subject:</span>
-                <span>{msg.subject}</span>
-              </div>
+              <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link
                   to={`/messages/${msg.id}/`}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import { Mail, User } from "lucide-react";
+
 import { Link } from "react-router-dom";
 import styles from "../../styles/OutboxList.module.css";
 
@@ -40,37 +40,32 @@ const OutboxList = () => {
     ? messages.results
     : [];
 
+  const sortedMessages = [...messageList].sort(
+    (a, b) => new Date(b.created_at) - new Date(a.created_at)
+  );
+
   return (
     <div className={styles.Container}>
       <h2 className={styles.Title}>Outbox</h2>
       {messageList.length === 0 && <div>No sent messages.</div>}
       <ul className={styles.List}>
-        {messageList.map((msg) => {
+        {sortedMessages.map((msg) => {
           const isRead =
             msg.read === true ||
             msg.read === "true" ||
             msg.read === 1 ||
             msg.read === "1";
+          const formattedDate = new Date(msg.created_at).toLocaleDateString(
+            "en-GB",
+            { day: "2-digit", month: "short", year: "numeric" }
+          );
           return (
             <li key={msg.id} className={styles.Message}>
               <div className={styles.MessageHeader}>
-                <div className="flex items-center gap-2">
-                  <User className="w-4 h-4" />
-                  <span className="font-semibold">To:</span>
-                  <span>
-                    {msg.receiver_username ||
-                      msg.recipient_username ||
-                      msg.receiver ||
-                      msg.recipient}
-                  </span>
-                </div>
+                <span className={styles.Date}>{formattedDate}</span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
-              <div className={styles.MessageBody}>
-                <Mail className="w-4 h-4" />
-                <span className="font-semibold">Subject:</span>
-                <span>{msg.subject}</span>
-              </div>
+              <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link
                   to={`/messages/${msg.id}/`}

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -17,28 +17,8 @@
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
 }
 
-.Subject {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1rem;
-}
-
-.Meta {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: 500;
-  margin-bottom: 0.75rem;
-}
-
 .Content {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  margin: 1.25rem 0;
+  margin-bottom: 1rem;
   line-height: 1.6;
   white-space: pre-line;
 }

--- a/src/styles/InboxList.module.css
+++ b/src/styles/InboxList.module.css
@@ -33,17 +33,25 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
 }
 
 .MessageHeader {
-display: flex;
-align-items: center;
-justify-content: space-between;
-font-weight: 600;
-color: #34495e;
-margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    color: #34495e;
+    margin-bottom: 8px;
 }
 
-.MessageBody {
-margin: 8px 0;
-color: #333;
+.Date {
+    font-size: 0.875rem;
+    color: #555;
+}
+
+.Preview {
+    margin: 4px 0 8px;
+    color: #333;
+    max-height: 3em;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .MessageFooter {

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -33,17 +33,25 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
 }
 
 .MessageHeader {
-display: flex;
-align-items: center;
-justify-content: space-between;
-font-weight: 600;
-color: #34495e;
-margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+    color: #34495e;
+    margin-bottom: 8px;
 }
 
-.MessageBody {
-margin: 8px 0;
-color: #333;
+.Date {
+    font-size: 0.875rem;
+    color: #555;
+}
+
+.Preview {
+    margin: 4px 0 8px;
+    color: #333;
+    max-height: 3em;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .MessageFooter {


### PR DESCRIPTION
## Summary
- simplify inbox list to show date and message preview only
- simplify outbox list similarly
- remove subject, sender and recipient info from message detail
- clean up messaging styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9170a34083308b9504631c1a897c