### PR TITLE
Improve inbox/outbox previews

### DIFF
--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -63,6 +63,15 @@ const InboxList = () => {
                 <span className={styles.Date}>{formattedDate}</span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
+              <div className={styles.Meta}>
+                <span className={styles.MetaItem}>
+                  <i className="fas fa-user" /> From:&nbsp;
+                  {msg.sender_username || msg.owner || msg.sender}
+                </span>
+                <span className={styles.MetaItem}>
+                  <i className="fas fa-envelope" /> {msg.subject}
+                </span>
+              </div>
               <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link

--- a/src/pages/inbox/InboxList.module.css
+++ b/src/pages/inbox/InboxList.module.css
@@ -33,12 +33,28 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
 }
 
 .MessageHeader {
-display: flex;
-align-items: center;
-justify-content: space-between;
-font-weight: 600;
-color: #34495e;
-margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  color: #34495e;
+  margin-bottom: 10px;
+}
+
+.Meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #555;
+  margin-bottom: 8px;
+  align-items: center;
+}
+
+.MetaItem {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .MessageBody {

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -65,6 +65,19 @@ const OutboxList = () => {
                 <span className={styles.Date}>{formattedDate}</span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
+              <div className={styles.Meta}>
+                <span className={styles.MetaItem}>
+                  <i className="fas fa-user" /> To:&nbsp;
+                  {msg.recipient_username ||
+                    msg.receiver_username ||
+                    msg.to_user?.username ||
+                    msg.recipient ||
+                    msg.receiver}
+                </span>
+                <span className={styles.MetaItem}>
+                  <i className="fas fa-envelope" /> {msg.subject}
+                </span>
+              </div>
               <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -41,6 +41,22 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
     margin-bottom: 8px;
 }
 
+.Meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: #555;
+    margin-bottom: 8px;
+    align-items: center;
+}
+
+.MetaItem {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
 .Date {
     font-size: 0.875rem;
     color: #555;


### PR DESCRIPTION
## Summary
- show sender and subject information in inbox list
- show recipient and subject information in outbox list
- add icons and styling for the new meta information

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a971ec38c8330afb3d01368901d2a