### PR TITLE
Improve inbox/outbox layout

### DIFF
--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -60,7 +60,9 @@ const InboxList = () => {
           return (
             <li key={msg.id} className={styles.Message}>
               <div className={styles.MessageHeader}>
-                <span className={styles.Date}>{formattedDate}</span>
+                <span className={styles.Date}>
+                  <i className="fas fa-calendar-alt" /> {formattedDate}
+                </span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
               <div className={styles.Meta}>
@@ -69,10 +71,10 @@ const InboxList = () => {
                   {msg.sender_username || msg.owner || msg.sender}
                 </span>
                 <span className={styles.MetaItem}>
-                  <i className="fas fa-envelope" /> {msg.subject}
+                  <i className="fas fa-envelope" /> Subject:&nbsp;
+                  {msg.subject}
                 </span>
               </div>
-              <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link
                   to={`/messages/${msg.id}/`}

--- a/src/pages/inbox/InboxList.module.css
+++ b/src/pages/inbox/InboxList.module.css
@@ -57,9 +57,12 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
   gap: 0.25rem;
 }
 
-.MessageBody {
-margin: 8px 0;
-color: #333;
+.Date {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  color: #555;
 }
 
 .MessageFooter {

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -62,7 +62,9 @@ const OutboxList = () => {
           return (
             <li key={msg.id} className={styles.Message}>
               <div className={styles.MessageHeader}>
-                <span className={styles.Date}>{formattedDate}</span>
+                <span className={styles.Date}>
+                  <i className="fas fa-calendar-alt" /> {formattedDate}
+                </span>
                 {!isRead && <span className={styles.UnreadDot}></span>}
               </div>
               <div className={styles.Meta}>
@@ -75,10 +77,10 @@ const OutboxList = () => {
                     msg.receiver}
                 </span>
                 <span className={styles.MetaItem}>
-                  <i className="fas fa-envelope" /> {msg.subject}
+                  <i className="fas fa-envelope" /> Subject:&nbsp;
+                  {msg.subject}
                 </span>
               </div>
-              <div className={styles.Preview}>{msg.content}</div>
               <div className={styles.MessageFooter}>
                 <Link
                   to={`/messages/${msg.id}/`}

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -58,16 +58,11 @@ box-shadow: 0 12px 20px rgba(0, 0, 0, 0.12);
 }
 
 .Date {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
     font-size: 0.875rem;
     color: #555;
-}
-
-.Preview {
-    margin: 4px 0 8px;
-    color: #333;
-    max-height: 3em;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .MessageFooter {


### PR DESCRIPTION
## Summary
- trim message previews from inbox and outbox lists
- show metadata only with calendar/user/envelope icons
- clean up CSS for inbox and outbox list pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a99e342308330a50fbde4a8550cbb