### PR TITLE
Simplify direct message detail view

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -47,9 +47,9 @@ const DirectMessageDetail = () => {
     msg.to_user?.username === currentUser?.username ||
     msg.recipient === currentUser?.username ||
     msg.receiver === currentUser?.username;
-  const isSender =
-    msg.sender_username === currentUser?.username ||
-    msg.owner === currentUser?.username;
+  // const isSender =
+  //   msg.sender_username === currentUser?.username ||
+  //   msg.owner === currentUser?.username;
   const cameFrom = location.state?.from;
   const backTarget =
     cameFrom === "inbox"
@@ -78,13 +78,8 @@ const DirectMessageDetail = () => {
         ← Back to {backLabel}
       </button>
       <div className={styles.Card}>
-        <div className={styles.Content}>{msg.content}</div>
-        <div className={styles.Date}>{formattedDate}</div>
-        {isSender && (
-          <div className={styles.Status}>
-            {msg.read === true || msg.read === "true" || msg.read === 1 || msg.read === "1" ? "Read" : "Unread"}
-          </div>
-        )}
+        <div className={styles.Date}>📅 {formattedDate}</div>
+        <div className={styles.Content}>📨 {msg.content?.trim() || "No message content."}</div>
       </div>
     </div>
   );

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -1,24 +1,20 @@
+
 .Container {
   max-width: 700px;
   margin: 40px auto;
+  padding: 24px;
+  background-color: #f9f9f9;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .Card {
-  background-color: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  padding: 24px;
-  font-size: 1rem;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
 }
 
-.Card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
-}
 
 .Content {
-  margin-bottom: 1rem;
+  margin-top: 0.5rem;
   line-height: 1.6;
   white-space: pre-line;
 }
@@ -26,16 +22,10 @@
 .Date {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.25rem;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   color: #555;
+  margin-bottom: 0.5rem;
 }
 
-.Status {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.875rem;
-  color: #555;
-  margin-top: 0.5rem;
-}


### PR DESCRIPTION
## Summary
- display only date and message body in DirectMessageDetail
- tidy up styles for the detail view

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9f11f48c8330a1f35a451e49c888