### PR TITLE
Refactor messaging UI

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -4,6 +4,13 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
 import styles from "../../styles/DirectMessageDetail.module.css";
 
+const formatDate = (dateString) =>
+  new Date(dateString).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
 const DirectMessageDetail = () => {
   const { id } = useParams();
   const [msg, setMsg] = useState(null);
@@ -44,11 +51,13 @@ const DirectMessageDetail = () => {
     <div className={styles.Container}>
       {msg ? (
         <div className={styles.MessageBox}>
-          <h2 className={styles.Subject}>📝 {msg.subject}</h2>
-          <p className={styles.From}>👤 From: {msg.sender_username}</p>
-          <p className={styles.To}>📨 To: {msg.recipient_username}</p>
-          <p className={styles.Date}>📅 {msg.created_at?.slice(0, 10)}</p>
+          <div className={styles.HeaderRow}>
+            <span className={styles.Date}>📅 {formatDate(msg.created_at)}</span>
+            <span className={styles.Subject}>📧 {msg.subject}</span>
+          </div>
           <div className={styles.Body}>💬 {msg.message}</div>
+          <p className={styles.From}>👤 From: {msg.sender_username}</p>
+          <p className={styles.To}>👤 To: {msg.recipient_username}</p>
         </div>
       ) : (
         <p>Loading message...</p>

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -3,6 +3,13 @@ import { axiosReq } from "../../api/axiosDefaults";
 import styles from "../../styles/InboxList.module.css";
 import { Link } from "react-router-dom";
 
+const formatDate = (dateString) =>
+  new Date(dateString).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
 const InboxList = () => {
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -36,10 +43,13 @@ const InboxList = () => {
         <ul className={styles.List}>
           {messages.map((msg) => (
             <li key={msg.id} className={styles.Message}>
-              <Link to={`/messages/${msg.id}`}>
-                <p className={styles.Subject}>📝 {msg.subject}</p>
-                <p className={styles.Info}>👤 From: {msg.sender}</p>
-                <p className={styles.Date}>📅 {msg.created_at?.slice(0, 10)}</p>
+              <p className={styles.Date}>📅 {formatDate(msg.created_at)}</p>
+              <p className={styles.Subject}>📧 {msg.subject}</p>
+              <p className={styles.Info}>
+                From: {msg.sender_username || msg.sender}
+              </p>
+              <Link className={styles.ReadLink} to={`/messages/${msg.id}`}>
+                Read
               </Link>
             </li>
           ))}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -3,6 +3,13 @@ import { axiosReq } from "../../api/axiosDefaults";
 import styles from "../../styles/OutboxList.module.css";
 import { Link } from "react-router-dom";
 
+const formatDate = (dateString) =>
+  new Date(dateString).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
 const OutboxList = () => {
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -36,10 +43,18 @@ const OutboxList = () => {
         <ul className={styles.List}>
           {messages.map((msg) => (
             <li key={msg.id} className={styles.Message}>
-              <Link to={`/messages/${msg.id}`}>
-                <p className={styles.Subject}>📝 {msg.subject}</p>
-                <p className={styles.Info}>📨 To: {msg.recipient}</p>
-                <p className={styles.Date}>📅 {msg.created_at?.slice(0, 10)}</p>
+              <p className={styles.Date}>📅 {formatDate(msg.created_at)}</p>
+              <p className={styles.Subject}>📧 {msg.subject}</p>
+              <p className={styles.Info}>
+                👤 To: {msg.recipient_username || msg.recipient}
+              </p>
+              <p className={styles.Info}>👤 From: Me</p>
+              <Link
+                className={styles.ReadLink}
+                to={`/messages/${msg.id}`}
+                state={{ from: "outbox" }}
+              >
+                Read
               </Link>
             </li>
           ))}

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -11,14 +11,23 @@
   box-shadow: 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.HeaderRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
 .Subject {
   font-size: 1.5rem;
   font-weight: bold;
   color: #2c3e50;
-  margin-bottom: 10px;
 }
 
-.From, .To, .Date {
+.From,
+.To,
+.Date {
   font-size: 0.95rem;
   color: #555;
   margin-bottom: 6px;

--- a/src/styles/InboxList.module.css
+++ b/src/styles/InboxList.module.css
@@ -34,7 +34,20 @@
   margin-bottom: 6px;
 }
 
-.Info, .Date {
+.Info,
+.Date {
   font-size: 0.9rem;
   color: #555;
+  margin-bottom: 6px;
+}
+
+.ReadLink {
+  color: #3498db;
+  text-decoration: none;
+  font-weight: bold;
+  transition: color 0.3s ease;
+}
+
+.ReadLink:hover {
+  color: #2c3e50;
 }

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -34,7 +34,20 @@
   margin-bottom: 6px;
 }
 
-.Info, .Date {
+.Info,
+.Date {
   font-size: 0.9rem;
   color: #555;
+  margin-bottom: 6px;
+}
+
+.ReadLink {
+  color: #3498db;
+  text-decoration: none;
+  font-weight: bold;
+  transition: color 0.3s ease;
+}
+
+.ReadLink:hover {
+  color: #2c3e50;
 }


### PR DESCRIPTION
## Summary
- update Inbox message cards to show username, date and subject
- adjust Outbox cards with sender and recipient info
- refactor direct message detail header
- update styles for the new layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aba63bf0483308b10d3bd8b27b183