### PR TITLE
Refactor messaging UI

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -47,8 +47,17 @@ const DirectMessageDetail = () => {
     }
   }, [id, mounted, currentUser, navigate]);
 
+  const backTo = location.state?.from === "outbox" ? "/outbox" : "/inbox";
+
   return (
     <div className={styles.Container}>
+      <button
+        className={styles.BackButton}
+        type="button"
+        onClick={() => navigate(backTo)}
+      >
+        ← Back to {location.state?.from === "outbox" ? "Outbox" : "Inbox"}
+      </button>
       {msg ? (
         <div className={styles.MessageBox}>
           <div className={styles.HeaderRow}>
@@ -56,8 +65,11 @@ const DirectMessageDetail = () => {
             <span className={styles.Subject}>📧 {msg.subject}</span>
           </div>
           <div className={styles.Body}>💬 {msg.message}</div>
-          <p className={styles.From}>👤 From: {msg.sender_username}</p>
-          <p className={styles.To}>👤 To: {msg.recipient_username}</p>
+          {location.state?.from === "outbox" ? (
+            <p className={styles.To}>👤 To: {msg.recipient_username}</p>
+          ) : (
+            <p className={styles.From}>👤 From: {msg.sender_username}</p>
+          )}
         </div>
       ) : (
         <p>Loading message...</p>

--- a/src/pages/inbox/InboxList.js
+++ b/src/pages/inbox/InboxList.js
@@ -46,7 +46,7 @@ const InboxList = () => {
               <p className={styles.Date}>📅 {formatDate(msg.created_at)}</p>
               <p className={styles.Subject}>📧 {msg.subject}</p>
               <p className={styles.Info}>
-                From: {msg.sender_username || msg.sender}
+                👤 From: {msg.sender_username || msg.sender}
               </p>
               <Link className={styles.ReadLink} to={`/messages/${msg.id}`}>
                 Read

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -48,7 +48,6 @@ const OutboxList = () => {
               <p className={styles.Info}>
                 👤 To: {msg.recipient_username || msg.recipient}
               </p>
-              <p className={styles.Info}>👤 From: Me</p>
               <Link
                 className={styles.ReadLink}
                 to={`/messages/${msg.id}`}
@@ -56,6 +55,9 @@ const OutboxList = () => {
               >
                 Read
               </Link>
+              <span className={styles.StatusBadge}>
+                {msg.read ? "✅" : "🔴"}
+              </span>
             </li>
           ))}
         </ul>

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -38,3 +38,16 @@
   font-size: 1rem;
   color: #333;
 }
+
+.BackButton {
+  background: none;
+  border: none;
+  color: #3498db;
+  cursor: pointer;
+  margin-bottom: 16px;
+  font-size: 1rem;
+}
+
+.BackButton:hover {
+  text-decoration: underline;
+}

--- a/src/styles/InboxList.module.css
+++ b/src/styles/InboxList.module.css
@@ -22,6 +22,7 @@
   box-shadow: 2px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 16px;
   padding: 16px;
+  position: relative;
   transition: transform 0.2s ease;
 }
 

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -22,6 +22,7 @@
   box-shadow: 2px 4px rgba(0, 0, 0, 0.1);
   margin-bottom: 16px;
   padding: 16px;
+  position: relative;
   transition: transform 0.2s ease;
 }
 
@@ -50,4 +51,11 @@
 
 .ReadLink:hover {
   color: #2c3e50;
+}
+
+.StatusBadge {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- tweak inbox list display
- show recipient and read status in outbox
- add navigation and conditional footer in direct message view
- style message cards and add back button styles

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac01643d88330a1e894dbb160ae02