### PR TITLE
Refine inbox/outbox UI

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -65,11 +65,11 @@ const DirectMessageDetail = () => {
         <CardFooter className={styles.Footer}>
           <div className={styles.FooterGroup}>
             <User className={styles.Icon} />
-            <span>From: {msg.sender_username}</span>
-          </div>
-          <div className={styles.FooterGroup}>
-            <User className={styles.Icon} />
-            <span>To: {msg.recipient_username}</span>
+            {fromView === "Outbox" ? (
+              <span>To: {msg.recipient_username}</span>
+            ) : (
+              <span>From: {msg.sender_username}</span>
+            )}
           </div>
         </CardFooter>
       </Card>

--- a/src/styles/DirectMessageDetail.module.css
+++ b/src/styles/DirectMessageDetail.module.css
@@ -65,7 +65,7 @@
 
 .Footer {
   display: flex;
-  gap: 24px;
+  gap: 8px;
   margin-top: 16px;
 }
 

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -57,7 +57,7 @@
 
 .StatusBadge {
   position: absolute;
-  bottom: 8px;
-  right: 8px;
-  font-size: 1rem;
+  right: 12px;
+  top: 16px;
+  font-size: 0.8rem;
 }


### PR DESCRIPTION
## Summary
- show only sender or recipient in message details
- tweak spacing in detail footer
- reposition outbox read check icon

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac8bd664483309f0e288ebf0f885c