### PR TITLE
Update outbox list and detail styling

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -3,9 +3,15 @@ import { useParams, useNavigate } from "react-router-dom";
 import { axiosReq } from "../../api/axiosDefaults";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
 import { Calendar, Mail, User, MessageCircle } from "lucide-react";
-import styles from "../../styles/DirectMessageDetail.module.css";
+import styles from "./DirectMessageDetail.module.css";
 import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
 
+const formatDate = (dateString) =>
+  new Date(dateString).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
 const DirectMessageDetail = () => {
   const { id } = useParams();
   const [msg, setMsg] = useState({});
@@ -41,20 +47,10 @@ const DirectMessageDetail = () => {
 
       <Card>
         <CardHeader className={styles.Header}>
-          <div className={styles.HeaderGroup}>
-            <Calendar className={styles.Icon} />
-            <span className={styles.Date}>
-              {new Date(msg.timestamp).toLocaleDateString("en-GB", {
-                day: "2-digit",
-                month: "short",
-                year: "numeric",
-              })}
-            </span>
-          </div>
-          <div className={styles.HeaderGroup}>
-            <Mail className={styles.Icon} />
-            <h2 className={styles.Subject}>{msg.subject}</h2>
-          </div>
+          <Calendar className={styles.Icon} />
+          <span className={styles.Date}>{formatDate(msg.timestamp)}</span>
+          <Mail className={styles.Icon} />
+          <h2 className={styles.Subject}>{msg.subject}</h2>
         </CardHeader>
 
         <CardContent className={styles.Content}>
@@ -63,14 +59,12 @@ const DirectMessageDetail = () => {
         </CardContent>
 
         <CardFooter className={styles.Footer}>
-          <div className={styles.FooterGroup}>
-            <User className={styles.Icon} />
-            {fromOutbox ? (
-              <span>To: {msg.recipient_username}</span>
-            ) : (
-              <span>From: {msg.sender_username}</span>
-            )}
-          </div>
+          <User className={styles.Icon} />
+          {fromOutbox ? (
+            <span>To: {msg.recipient_username}</span>
+          ) : (
+            <span>From: {msg.sender_username}</span>
+          )}
         </CardFooter>
       </Card>
     </div>

--- a/src/pages/inbox/DirectMessageDetail.module.css
+++ b/src/pages/inbox/DirectMessageDetail.module.css
@@ -1,0 +1,53 @@
+.Container {
+  max-width: 700px;
+  margin: 40px auto;
+  padding: 0 16px;
+}
+
+.BackButton {
+  background: none;
+  border: 1px solid #333;
+  border-radius: 4px;
+  color: #333;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+.Header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.Icon {
+  width: 20px;
+  height: 20px;
+  color: #6b7280;
+}
+
+.Subject {
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin: 0;
+}
+
+.Content {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.Content p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.Footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+}

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { axiosReq } from "../../api/axiosDefaults";
-import styles from "../../styles/OutboxList.module.css";
 import { Link } from "react-router-dom";
+import {
+  Calendar,
+  Mail,
+  User,
+  Check,
+  Dot,
+} from "lucide-react";
+import styles from "./OutboxList.module.css";
 
 const formatDate = (dateString) =>
   new Date(dateString).toLocaleDateString("en-GB", {
@@ -48,12 +55,23 @@ const OutboxList = () => {
                 to={`/messages/${msg.id}`}
                 state={{ from: "outbox" }}
               >
-                <p className={styles.Date}>📅 {formatDate(msg.timestamp)}</p>
-                <p className={styles.Subject}>✉️ {msg.subject}</p>
-                <p className={styles.Info}>👤 To: {msg.recipient_username}</p>
-                <span className={styles.StatusBadge}>
-                  {msg.readByRecipient ? "✅" : "🔴"}
-                </span>
+                <div className={styles.Row}>
+                  <Calendar className={styles.Icon} />
+                  <span className={styles.Date}>{formatDate(msg.timestamp)}</span>
+                </div>
+                <div className={styles.Row}>
+                  <Mail className={styles.Icon} />
+                  <span className={styles.Subject}>{msg.subject}</span>
+                </div>
+                <div className={styles.Row}>
+                  <User className={styles.Icon} />
+                  <span className={styles.Recipient}>To: {msg.recipient_username}</span>
+                </div>
+                {msg.readByRecipient ? (
+                  <Check className={styles.StatusIcon} />
+                ) : (
+                  <Dot className={styles.StatusIcon} />
+                )}
               </Link>
             </li>
           ))}

--- a/src/pages/inbox/OutboxList.module.css
+++ b/src/pages/inbox/OutboxList.module.css
@@ -1,0 +1,69 @@
+.Container {
+  max-width: 700px;
+  margin: 40px auto;
+  padding: 0 16px;
+}
+
+.Title {
+  text-align: center;
+  margin-bottom: 20px;
+  font-size: 1.8rem;
+  color: #2c3e50;
+}
+
+.List {
+  list-style: none;
+  padding: 0;
+}
+
+.Message {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: #ffffff;
+  border-radius: 10px;
+  box-shadow: 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 16px;
+  margin-bottom: 16px;
+  transition: transform 0.2s ease;
+}
+
+.Message:hover {
+  transform: scale(1.02);
+}
+
+.MessageLink {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.Row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.Subject {
+  font-weight: bold;
+}
+
+.StatusIcon {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 16px;
+  height: 16px;
+  color: #6b7280;
+}
+
+.Icon {
+  width: 16px;
+  height: 16px;
+  color: #6b7280;
+}


### PR DESCRIPTION
## Summary
- revamp outbox list UI with icons and cleaned layout
- style outbox list cards for consistency with inbox
- streamline direct message detail view and adjust layout
- add matching CSS modules for new layouts

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acedf61448330bdfc9d90b9a7bf04