### PR TITLE
Fix outbox message display

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -48,7 +48,9 @@ const DirectMessageDetail = () => {
       <Card>
         <CardHeader className={styles.Header}>
           <Calendar className={styles.Icon} />
-          <span className={styles.Date}>{formatDate(msg.timestamp)}</span>
+          <span className={styles.Date}>
+            {formatDate(msg.created_at || msg.timestamp)}
+          </span>
           <Mail className={styles.Icon} />
           <h2 className={styles.Subject}>{msg.subject}</h2>
         </CardHeader>

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -57,7 +57,9 @@ const OutboxList = () => {
               >
                 <div className={styles.Row}>
                   <Calendar className={styles.Icon} />
-                  <span className={styles.Date}>{formatDate(msg.timestamp)}</span>
+                  <span className={styles.Date}>
+                    {formatDate(msg.created_at || msg.timestamp)}
+                  </span>
                 </div>
                 <div className={styles.Row}>
                   <Mail className={styles.Icon} />


### PR DESCRIPTION
## Summary
- tweak outbox list date formatting
- handle both `created_at` and `timestamp` fields in message detail

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad1dcc7a08330ac06c3832bcc0046