### PR TITLE
Fix UserIcon imports and show recipient name

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { axiosReq } from "../../api/axiosDefaults";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
-import { Calendar, Mail, MessageCircle } from "lucide-react";
-import { FaUser as UserIcon } from "react-icons/fa";
+import { Calendar, Mail, MessageCircle, UserIcon } from "lucide-react";
 import styles from "./DirectMessageDetail.module.css";
 import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
 

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -6,8 +6,8 @@ import {
   Mail,
   Check,
   Dot,
+  UserIcon,
 } from "lucide-react";
-import { FaUser as UserIcon } from "react-icons/fa";
 import styles from "./OutboxList.module.css";
 
 const formatDate = (dateString) =>
@@ -67,7 +67,8 @@ const OutboxList = () => {
                 </div>
                 <div className={styles.Row}>
                   <UserIcon className={styles.Icon} />
-                  <span className={styles.Recipient}>To: {msg.recipient_username}</span>
+                  <span>To:</span>
+                  <span className={styles.Recipient}>{msg.recipient_username}</span>
                 </div>
                 {msg.readByRecipient ? (
                   <Check className={styles.StatusIcon} />


### PR DESCRIPTION
## Summary
- import `UserIcon` from lucide-react in outbox and detail views
- display recipient username next to `To:` in outbox list

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adf35eabc8330804847ebbffd2c7c