### PR TITLE
Fix UserIcon imports

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { axiosReq } from "../../api/axiosDefaults";
 import { useCurrentUser } from "../../contexts/CurrentUserContext";
-import { Calendar, Mail, MessageCircle, UserIcon } from "lucide-react";
+import { Calendar, Mail, MessageCircle, User as UserIcon } from "lucide-react";
 import styles from "./DirectMessageDetail.module.css";
 import { Card, CardHeader, CardContent, CardFooter } from "../../components/ui/card";
 

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -6,7 +6,7 @@ import {
   Mail,
   Check,
   Dot,
-  UserIcon,
+  User as UserIcon,
 } from "lucide-react";
 import styles from "./OutboxList.module.css";
 


### PR DESCRIPTION
## Summary
- fix lucide-react imports to use `User as UserIcon`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcbf457e88330ba78c0c3ee836b3c