### PR TITLE
Show recipients in Outbox

### DIFF
--- a/src/pages/inbox/DirectMessageDetail.js
+++ b/src/pages/inbox/DirectMessageDetail.js
@@ -63,9 +63,9 @@ const DirectMessageDetail = () => {
         <CardFooter className={styles.Footer}>
           <UserIcon className={styles.Icon} />
           {fromOutbox ? (
-            <span>To: {msg.recipient_username}</span>
+            <span>To: {msg.recipient_username || "—"}</span>
           ) : (
-            <span>From: {msg.sender_username}</span>
+            <span>From: {msg.sender_username || "—"}</span>
           )}
         </CardFooter>
       </Card>

--- a/src/pages/inbox/OutboxList.js
+++ b/src/pages/inbox/OutboxList.js
@@ -65,10 +65,8 @@ const OutboxList = () => {
                   <Mail className={styles.Icon} />
                   <span className={styles.Subject}>{msg.subject}</span>
                 </div>
-                <div className={styles.Row}>
-                  <UserIcon className={styles.Icon} />
-                  <span>To:</span>
-                  <span className={styles.Recipient}>{msg.recipient_username}</span>
+                <div className={styles.Recipient}>
+                  <UserIcon className={styles.Icon} /> To: {msg.recipient_username || "—"}
                 </div>
                 {msg.readByRecipient ? (
                   <Check className={styles.StatusIcon} />

--- a/src/styles/OutboxList.module.css
+++ b/src/styles/OutboxList.module.css
@@ -67,3 +67,11 @@
   height: 16px;
   color: #6b7280;
 }
+
+.Recipient {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.9rem;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- show the recipient under each message in the Outbox list
- only display `To:` or `From:` in message detail depending on view
- add style for new recipient row

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd36cb2188330a659bea54862cf73