### PR TITLE
Add notification WebSocket hook and inbox badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.30.1",
     "react-scripts": "^5.0.1",
+    "reconnecting-websocket": "^4.4.0",
     "sweetalert2": "^11.14.5",
     "typescript": "^4.4.0",
     "web-vitals": "^1.1.2"

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -3,6 +3,7 @@ import { Navbar, Container, Nav } from "react-bootstrap";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useCurrentUser, useSetCurrentUser } from "../contexts/CurrentUserContext";
 import useClickOutsideToggle from "../hooks/useClickOutsideToggle";
+import useNotificationSocket from "../hooks/useNotificationSocket";
 import { removeTokenTimestamp } from "../utils/utils";
 import Swal from "sweetalert2";
 import Avatar from "./Avatar";
@@ -16,6 +17,8 @@ const NavBar = () => {
   const navigate = useNavigate();
 
   const { expanded, setExpanded, ref } = useClickOutsideToggle();
+  const { notifications, clearNotifications } = useNotificationSocket();
+  const unreadCount = notifications.length;
 
   const handleSignOut = async () => {
     try {
@@ -69,8 +72,13 @@ const NavBar = () => {
       className={styles.NavLink}
       activeClassName={styles.Active}
       to="/inbox"
+      onClick={clearNotifications}
     >
-      <i className="fas fa-inbox"></i>Inbox
+      <i className="fas fa-inbox"></i>
+      Inbox
+      {unreadCount > 0 && (
+        <span className={styles.Badge}>{unreadCount}</span>
+      )}
     </NavLink>
   );
 

--- a/src/hooks/useNotificationSocket.js
+++ b/src/hooks/useNotificationSocket.js
@@ -1,0 +1,35 @@
+import { useEffect, useState, useRef } from "react";
+import ReconnectingWebSocket from "reconnecting-websocket";
+
+export default function useNotificationSocket() {
+  const [notifications, setNotifications] = useState([]);
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "test") return;
+    // choose ws:// or wss:// based on page protocol
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    const socketUrl = `${protocol}://${window.location.host}/ws/notifications/`;
+    wsRef.current = new ReconnectingWebSocket(socketUrl);
+
+    wsRef.current.onmessage = ({ data }) => {
+      try {
+        const event = JSON.parse(data);
+        // push into array
+        setNotifications((prev) => [...prev, event]);
+      } catch (e) {
+        console.error("Invalid WebSocket payload:", e);
+      }
+    };
+
+    return () => {
+      wsRef.current.close();
+    };
+  }, []);
+
+  const clearNotifications = () => {
+    setNotifications([]);
+  };
+
+  return { notifications, clearNotifications };
+}

--- a/src/styles/NavBar.module.css
+++ b/src/styles/NavBar.module.css
@@ -82,3 +82,28 @@
     padding: 10px;
   }
 }
+
+.Badge {
+  position: absolute;
+  top: -4px;
+  right: -8px;
+  background-color: #e53e3e;
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  line-height: 1;
+  animation: pulse 1.5s ease-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(229, 62, 62, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(229, 62, 62, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(229, 62, 62, 0);
+  }
+}


### PR DESCRIPTION
## Summary
- create `useNotificationSocket` hook for websocket notifications
- integrate hook into `NavBar` to display inbox badge
- add badge styles and animation
- include `reconnecting-websocket` dependency

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865250fd0988330aadda3c2ea689315