### PR TITLE
Add notification dropdown to NavBar

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Navbar, Container, Nav } from "react-bootstrap";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useCurrentUser, useSetCurrentUser } from "../contexts/CurrentUserContext";
@@ -18,6 +18,7 @@ const NavBar = () => {
 
   const { expanded, setExpanded, ref } = useClickOutsideToggle();
   const { notifications, clearNotifications } = useNotificationSocket();
+  const [notifOpen, setNotifOpen] = useState(false);
   const unreadCount = notifications.length;
 
   const handleSignOut = async () => {
@@ -142,6 +143,35 @@ const NavBar = () => {
       {inboxIcon}
       {outboxIcon}
       {newMessageIcon}
+      <div className={styles.NotifWrapper}>
+        <button
+          className={styles.NotifButton}
+          onClick={() => {
+            setNotifOpen((o) => !o);
+            if (!notifOpen) clearNotifications();
+          }}
+          aria-label="Notifications"
+        >
+          <i className="fas fa-bell"></i>
+          {unreadCount > 0 && (
+            <span className={styles.NotifBadge}>{unreadCount}</span>
+          )}
+        </button>
+
+        {notifOpen && (
+          <ul className={styles.NotifDropdown}>
+            {notifications.length ? (
+              notifications.map((n) => (
+                <li key={n.id} className={styles.NotifItem}>
+                  {n.message}
+                </li>
+              ))
+            ) : (
+              <li className={styles.NotifEmpty}>No new notifications</li>
+            )}
+          </ul>
+        )}
+      </div>
 
       <NavLink
         className={styles.NavLink}

--- a/src/styles/NavBar.module.css
+++ b/src/styles/NavBar.module.css
@@ -107,3 +107,55 @@
     box-shadow: 0 0 0 0 rgba(229, 62, 62, 0);
   }
 }
+
+.NotifWrapper {
+  position: relative;
+  display: inline-block;
+  margin: 0 1rem;
+}
+
+.NotifButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  color: inherit;
+  font-size: 1.2rem;
+}
+
+.NotifBadge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 0.7rem;
+}
+
+.NotifDropdown {
+  position: absolute;
+  right: 0;
+  top: 28px;
+  width: 220px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+  z-index: 1000;
+}
+
+.NotifItem,
+.NotifEmpty {
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.NotifItem:hover {
+  background: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- hook up notification socket to the NavBar
- display a bell icon with badge for unread messages
- show a dropdown with latest notifications
- style new notification UI in the navbar

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865499160a0833092836dd66a377e95