### PR TITLE
Add swinging bell icon for unread inbox messages

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -73,10 +73,9 @@ const NavBar = () => {
       activeClassName={styles.Active}
       to="/inbox"
     >
-      <i className="fas fa-inbox"></i>
-      Inbox
+      <i className="fas fa-inbox"></i> Inbox
       {unreadCount > 0 && (
-        <span className={styles.Badge}>{unreadCount}</span>
+        <Bell className={styles.BellIconActive} />
       )}
     </NavLink>
   );
@@ -101,15 +100,6 @@ const NavBar = () => {
     </NavLink>
   );
 
-  const notificationIcon = (
-    <NavLink
-      className={`${styles.NavLink} ${unreadCount > 0 ? styles.BellActive : ""}`}
-      to="/inbox"
-    >
-      <Bell className={styles.BellIcon} />
-      {unreadCount > 0 && <span className={styles.Badge}>{unreadCount}</span>}
-    </NavLink>
-  );
 
   // Logged-in Icons
   const loggedInIcons = (
@@ -152,7 +142,6 @@ const NavBar = () => {
       {outboxIcon}
       {newMessageIcon}
 
-      {notificationIcon}
 
       <NavLink
         className={styles.NavLink}

--- a/src/hooks/useUnreadMessagesCount.js
+++ b/src/hooks/useUnreadMessagesCount.js
@@ -1,40 +1,33 @@
 import { useState, useEffect } from "react";
 import { axiosReq } from "../api/axiosDefaults";
 
-/**
- * Hook zwraca liczbę nieprzeczytanych wiadomości w inbox
- * i odświeża ją co 30 sekund.
- */
 export default function useUnreadMessagesCount() {
-  const [unreadCount, setUnreadCount] = useState(0);
+  const [count, setCount] = useState(0);
 
   useEffect(() => {
-    let isMounted = true;
-
+    let mounted = true;
     const fetchCount = async () => {
       try {
-        // Zakładam, że GET /inbox/ zwraca paginowane results
         const { data } = await axiosReq.get("/inbox/?read=false");
         const items = Array.isArray(data)
           ? data
           : Array.isArray(data.results)
           ? data.results
           : [];
-        if (isMounted) {
-          setUnreadCount(items.length);
+        if (mounted) {
+          setCount(items.length);
         }
-      } catch (err) {
-        console.error("Failed to fetch unread count", err);
+      } catch {
+        // ignore
       }
     };
-
     fetchCount();
     const interval = setInterval(fetchCount, 30000);
     return () => {
-      isMounted = false;
+      mounted = false;
       clearInterval(interval);
     };
   }, []);
 
-  return unreadCount;
+  return count;
 }

--- a/src/styles/NavBar.module.css
+++ b/src/styles/NavBar.module.css
@@ -195,3 +195,22 @@
   75%  { transform: rotate(-15deg); }
   100% { transform: rotate(0deg); }
 }
+
+/* red swinging bell when there are unread messages */
+.BellIconActive {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  width: 18px;
+  height: 18px;
+  color: #e3342f;
+  animation: swing 1s infinite ease-in-out;
+}
+
+@keyframes swing {
+  0%   { transform: rotate(0deg); }
+  25%  { transform: rotate(15deg); }
+  50%  { transform: rotate(0deg); }
+  75%  { transform: rotate(-15deg); }
+  100% { transform: rotate(0deg); }
+}


### PR DESCRIPTION
## Summary
- poll unread inbox messages with useUnreadMessagesCount hook
- show a red swinging bell next to the Inbox link when there are unread messages
- remove old notification icon
- style bell icon

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686641e2e3a883309999868334d8ebe1