### PR TITLE
Refactor DM inbox bell icon

### DIFF
--- a/src/styles/NavBar.module.css
+++ b/src/styles/NavBar.module.css
@@ -108,102 +108,12 @@
   }
 }
 
-.NotifWrapper {
-  position: relative;
-  display: inline-block;
-  margin: 0 1rem;
-}
-
-.NotifButton {
-  background: none;
-  border: none;
-  cursor: pointer;
-  position: relative;
-  color: inherit;
-  font-size: 1.2rem;
-}
-
-.NotifBadge {
-  position: absolute;
-  top: -4px;
-  right: -6px;
-  background: red;
-  color: white;
-  border-radius: 50%;
-  padding: 2px 6px;
-  font-size: 0.7rem;
-}
-
-.NotifDropdown {
-  position: absolute;
-  right: 0;
-  top: 28px;
-  width: 220px;
-  background: white;
-  border: 1px solid #ddd;
-  border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  list-style: none;
-  margin: 0;
-  padding: 8px 0;
-  z-index: 1000;
-}
-
-.NotifItem,
-.NotifEmpty {
-  padding: 8px 12px;
-  font-size: 0.9rem;
-  color: #333;
-}
-
-.NotifItem:hover {
-  background: #f5f5f5;
-}
-
-/* Dzwoneczek */
-.BellIcon {
-  width: 20px;
-  height: 20px;
-  color: #6b7280;
-  transition: transform 0.2s ease, color 0.2s ease;
-}
-
-/* Kiedy są nieprzeczytane */
-.BellActive .BellIcon {
-  animation: swing 1s infinite ease-in-out;
-  color: #e3342f;
-}
-
-/* Czerwona kropka z licznikiem */
-.Badge {
-  background: #e3342f;
-  color: white;
-  font-size: 0.7rem;
-  padding: 0 6px;
-  border-radius: 12px;
-  position: absolute;
-  top: 0;
-  right: -6px;
-  transform: translate(50%, -50%);
-}
-
-/* Animacja "huśtawki" */
-@keyframes swing {
-  0%   { transform: rotate(0deg); }
-  25%  { transform: rotate(15deg); }
-  50%  { transform: rotate(0deg); }
-  75%  { transform: rotate(-15deg); }
-  100% { transform: rotate(0deg); }
-}
-
-/* red swinging bell when there are unread messages */
+/* Bell icon when there are unread DMs */
 .BellIconActive {
-  position: absolute;
-  top: 0;
-  right: -4px;
+  margin-left: 4px;
+  color: #e3342f;            /* vivid red */
   width: 18px;
   height: 18px;
-  color: #e3342f;
   animation: swing 1s infinite ease-in-out;
 }
 
@@ -212,5 +122,5 @@
   25%  { transform: rotate(15deg); }
   50%  { transform: rotate(0deg); }
   75%  { transform: rotate(-15deg); }
-  100% { transform: rotate(0deg); }
+  100%  { transform: rotate(0deg); }
 }


### PR DESCRIPTION
## Summary
- remove deprecated notification bell styles
- style active inbox bell icon to swing and be red
- inbox menu item uses bell icon inline when there are unread messages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664f20f98c8330ab51ed342080bc2d