### PR TITLE
Implement unread messages badge

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -74,6 +74,7 @@ const NavBar = () => {
     >
       <i className="fas fa-inbox"></i>
       Inbox
+      {/* only show badge when there are unread messages */}
       {unreadCount > 0 && (
         <span className={styles.Badge}>{unreadCount}</span>
       )}

--- a/src/hooks/useUnreadMessagesCount.js
+++ b/src/hooks/useUnreadMessagesCount.js
@@ -1,23 +1,31 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 import { axiosReq } from "../api/axiosDefaults";
 
 export default function useUnreadMessagesCount() {
   const [count, setCount] = useState(0);
 
-  useEffect(() => {
-    let isMounted = true;
-    async function fetchCount() {
-      try {
-        const { data } = await axiosReq.get("/inbox/?read=false");
-        if (isMounted) {
-          setCount(Array.isArray(data) ? data.length : data.results.length);
-        }
-      } catch (err) {
-        console.error(err);
-      }
+  const fetchCount = async () => {
+    try {
+      // GET all inbox messages where read=false
+      const { data } = await axiosReq.get("/inbox/", {
+        params: { read: false },
+      });
+      // support both paginated and non‑paginated responses
+      const unread = Array.isArray(data)
+        ? data.length
+        : Array.isArray(data?.results)
+        ? data.results.length
+        : 0;
+      setCount(unread);
+    } catch (err) {
+      console.error("Failed to fetch unread count:", err);
     }
+  };
+
+  useEffect(() => {
     fetchCount();
-    return () => { isMounted = false; };
+    // optional: poll or subscribe to real‑time events here
+    // e.g. setInterval(fetchCount, 30000);
   }, []);
 
   return count;

--- a/src/styles/NavBar.module.css
+++ b/src/styles/NavBar.module.css
@@ -84,31 +84,21 @@
   }
 }
 
+
 .Badge {
-  background: #e74c3c;
+  background-color: #e3342f;       /* red */
   color: white;
-  border-radius: 50%;
-  padding: 2px 6px;
+  border-radius: 9999px;
   font-size: 0.75rem;
-  position: absolute;
-  top: 0;
-  right: -6px;
-  animation: pulse 1.5s infinite;
+  padding: 0 6px;
+  margin-left: 4px;
+  vertical-align: middle;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes pulse {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.2);
-    opacity: 0.7;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.2); }
 }
 
 /* Bell icon when there are unread DMs */


### PR DESCRIPTION
## Summary
- add `useUnreadMessagesCount` hook for unread inbox messages
- display inbox badge using unread count
- style badge with pulsing animation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e12bd310c8330b0cc493f1730cf3c